### PR TITLE
Change TranscribeConfig type usage

### DIFF
--- a/src/speech_client.ts
+++ b/src/speech_client.ts
@@ -5,7 +5,7 @@ import * as protoLoader from "@grpc/proto-loader";
 
 import { ProtoGrpcType } from "../proto/speech_service";
 import { TranscribeStreamRequest } from "../proto/soniox/speech_service/TranscribeStreamRequest";
-import { TranscriptionConfig__Output } from "../proto/soniox/speech_service/TranscriptionConfig";
+import { TranscriptionConfig } from "../proto/soniox/speech_service/TranscriptionConfig";
 import { TranscribeAsyncRequest } from "../proto/soniox/speech_service/TranscribeAsyncRequest";
 import { GetTranscribeAsyncStatusRequest } from "../proto/soniox/speech_service/GetTranscribeAsyncStatusRequest";
 import { GetTranscribeAsyncResultRequest } from "../proto/soniox/speech_service/GetTranscribeAsyncResultRequest";
@@ -68,7 +68,7 @@ export class SpeechClient {
     this.connection.credentials
   );
 
-  private defaultRequestConfig: TranscriptionConfig__Output = {
+  private defaultRequestConfig: TranscriptionConfig = {
     audio_format: "",
     sample_rate_hertz: 0,
     num_audio_channels: 0,
@@ -129,7 +129,7 @@ export class SpeechClient {
     };
   }
 
-  private _validateConfig(config: TranscriptionConfig__Output) {
+  private _validateConfig(config: TranscriptionConfig) {
     for (const [key, value] of Object.entries(config)) {
       if (!this.defaultRequestConfig.hasOwnProperty(key)) {
         throw new Error(
@@ -141,7 +141,7 @@ export class SpeechClient {
 
   public transcribeFileShort = async (
     file_path: string,
-    config: TranscriptionConfig__Output
+    config: TranscriptionConfig
   ): Promise<Result__Output | Result__Output[]> => {
     if (!file_path) {
       throw new Error('Missing "file_path".');
@@ -187,7 +187,7 @@ export class SpeechClient {
   public transcribeFileAsync = async (
     file_path: string,
     reference_name: string,
-    config: TranscriptionConfig__Output
+    config: TranscriptionConfig
   ): Promise<string> => {
     if (!file_path) {
       throw new Error('Missing "file_path".');
@@ -382,7 +382,7 @@ export class SpeechClient {
   };
 
   public transcribeStream = (
-    config: TranscriptionConfig__Output,
+    config: TranscriptionConfig,
     onData: (result: Result__Output) => void,
     onEnd: (error: any) => void
   ): TranscribeStreamReturn => {


### PR DESCRIPTION
When creating a stream a TranscribeConfig_Output object is needed. 

The type definition of TranscribeConfig__Output requires all fields to be present. However, not all transcription configurations require all fields to be present. This causes an error when using typescript. 

The TranscribeConfig object instead allows for fields to be optional. 